### PR TITLE
Remove Hash Routing

### DIFF
--- a/cainafrica/src/App.js
+++ b/cainafrica/src/App.js
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import  {Switch, Route, HashRouter} from "react-router-dom";
+import  {Switch, Route, BrowserRouter} from "react-router-dom";
 import './App.css';
 
 //Displayed components
@@ -69,7 +69,7 @@ const App = () => {
   return (
     <div style={{height: "100%"}}>
       
-      <HashRouter>
+      <BrowserRouter>
         <Switch>
           <Route 
             path='/home' 
@@ -239,7 +239,7 @@ const App = () => {
           />
         </Switch>
         <Footer />
-      </HashRouter>
+      </BrowserRouter>
     </div>
   );
 }

--- a/cainafrica/src/serviceWorker.js
+++ b/cainafrica/src/serviceWorker.js
@@ -128,6 +128,12 @@ function checkValidServiceWorker(swUrl, config) {
     });
 }
 
+if (window.location.hash.startsWith("#/")) {
+  const cleanPath = window.location.hash.replace(/^#/, "");
+  window.location = cleanPath;
+}
+
+
 export function unregister() {
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.ready.then(registration => {


### PR DESCRIPTION
- Removes hash routing so that URLs will no longer have hash (i.e. https://www.cainafrica.org/#/projects becomes https://www.cainafrica.org/projects)
- Add redirect to continue supporting the hash links, in case other places are linking to them. From now on hash links will automatically redirect to the non-hash URL.
- Fix an unrelated file import. 